### PR TITLE
chore: use native arch if not specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ TKN_IMG ?= quay.io/rhqp/podman-desktop-e2e-tkn:v${TKN_TASK_VERSION}
 
 
 BUILD_DIR ?= out
-ARCH ?= amd64
+NATIVE_GOARCH := $(shell env -u GOARCH go env GOARCH)
+ARCH ?= $(NATIVE_GOARCH)
 
 # https://golang.org/cmd/link/
 LDFLAGS := $(VERSION_VARIABLES) -extldflags='-static' ${GO_EXTRA_LDFLAGS}


### PR DESCRIPTION
automatically detect current system arch if omitted
Dor example use arm64 if executed on a M2 mac

Change-Id: Ic5df8742bc1ace5673a9653b556b129ee0d09e9f